### PR TITLE
166 fix fse scheduling estimation

### DIFF
--- a/SNAP.html
+++ b/SNAP.html
@@ -14,7 +14,7 @@
         </div>
         <div id="new-window-menu">
             <ul>
-                <li><a href="#" target="_blank">New SNAP Form</a></li>
+                <li><a href="" onclick="newSnap()" target="_blank">New SNAP Form</a></li>
                 <li><a href="" onclick="generateNewWindowLink('account')" target="_blank">New SNAP Form with Account Data</a></li>
                 <li><a href="" onclick="generateNewWindowLink('instrument')" target="_blank">New SNAP Form with Instrument Data</a></li>
             </ul>

--- a/SNAP_sandbox.html
+++ b/SNAP_sandbox.html
@@ -17,7 +17,7 @@
         </div>
         <div id="new-window-menu">
             <ul>
-                <li><a href="#" target="_blank">New SNAP Form</a></li>
+                <li><a href="" onclick="newSnap()" target="_blank">New SNAP Form</a></li>
                 <li><a href="" onclick="generateNewWindowLink('account')" target="_blank">New SNAP Form with Account Data</a></li>
                 <li><a href="" onclick="generateNewWindowLink('instrument')" target="_blank">New SNAP Form with Instrument Data</a></li>
             </ul>

--- a/assets/js/dynamicFieldsLib.js
+++ b/assets/js/dynamicFieldsLib.js
@@ -638,16 +638,16 @@ function processSlaNote() {
         var cutoff_time = roundFifteenMinutes(sla_date.getMinutes(), sla_date.getHours());
         cutoff_time = cutoff_time.toString().padStart(2, '0')
         console.debug({cutoff_time});
-        fss_context.push(cutoff_time + ' today');
+        fss_context.push('end of business today');
     } else if (eob_status.match(/^eob/)) {
         console.log('SLA is past EOB');
         var eob_results = eob_status.split(':');
         var sla_overrun = (parseInt(eob_results[1]) + 9).toString().padStart(2, '0'); // Assuming the average clinic opening hour is 09:00
         console.debug({sla_overrun});
-        fss_context.push(sla_overrun + ':00 tomorrow');
+        fss_context.push('noon tomorrow');
     } else if (eob_status === 'weekend') {
         console.log('SLA is past EOB and extends into weekend');
-        fss_context.push('10:00 Monday'); // Setting a reasonable post-weekend window
+        fss_context.push('noon Monday'); // Setting a reasonable post-weekend window
     } else {
         console.error('checkEndOfBusiness function returned a non-valid result: ' + eob_status);
     }

--- a/assets/js/productData.js
+++ b/assets/js/productData.js
@@ -45,7 +45,7 @@ console.log('Loading productData.js...');
 function generateProductData() {
     console.debug('Executing generateProductData ...');
     this.pdata = {
-        "data_version": "1.14.0",
+        "data_version": "1.16.0",
         "schema_version": "8.4",
         "validated_date": "",
         "validated_ver": "",
@@ -335,7 +335,7 @@ function generateProductData() {
                         "eos_date": "",
                         "eogs_date": "",
                         "eos_url": "",
-                        "instrument_codes": []
+                        "instrument_codes": ["9801"]
                     },
                     "991": {
                         "model_serials": {},
@@ -2002,7 +2002,7 @@ function generateProductData() {
                         "full_name": "Pentero 800 S",
                         "launch_date": "",
                         "supported": true,
-                        "required_escalation": false,
+                        "required_escalation": true,
                         "eos_date": "",
                         "eogs_date": "",
                         "eos_url": "",
@@ -2178,7 +2178,7 @@ function generateProductData() {
                         "full_name": "Quatera 700",
                         "launch_date": "",
                         "supported": true,
-                        "required_escalation": true,
+                        "required_escalation": false,
                         "eos_date": "",
                         "eogs_date": "",
                         "eos_url": "",
@@ -2879,7 +2879,7 @@ function generateProductData() {
                         "eogs_date": "",
                         "eos_url": "",
                         "model_url": "",
-                        "instrument_codes": ["9138"]
+                        "instrument_codes": ["9138", "9149"]
                     },
                     "yag": {
                         "model_serials": {

--- a/assets/js/snaplib.js
+++ b/assets/js/snaplib.js
@@ -1,4 +1,4 @@
-const version = '3.1.16';
+const version = '3.1.17';
 const project_home = 'https://github.com/divonpleasant/SNAP'
 
 // Startup routine
@@ -661,4 +661,8 @@ function checkCookie() {
             setCookie('username', user, 365);
         }
     }
+}
+
+function newSnap() {
+    window.location.assign(window.location.href);
 }


### PR DESCRIPTION
Simplifies SLA estimation by not setting explicit times but giving broader windows (end of day, tomorrow noon, early next week, etc). This helps account for any delays between CCT creation and dispatch assignment and reduces liability for customers who may end up "watching the clock."

Also adds updates for young revenue in the productsData object and a few other QoL improvements.